### PR TITLE
[OUT-1429][MINOR] RxSwift 타겟 이름을 BuzzRxSwift로 변경

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -4407,7 +4407,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.buzzvil.BuzzRxSwift;
 				PRODUCT_NAME = RxSwift;
 				SKIP_INSTALL = YES;
 			};
@@ -4625,7 +4625,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.buzzvil.BuzzRxSwift;
 				PRODUCT_NAME = RxSwift;
 				SKIP_INSTALL = YES;
 			};
@@ -4641,7 +4641,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.buzzvil.BuzzRxSwift;
 				PRODUCT_NAME = RxSwift;
 				SKIP_INSTALL = YES;
 			};

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -2719,9 +2719,9 @@
 			productReference = C88FA50C1C25C44800CCFEA4 /* RxTest.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C8A56AD61AD7424700B4673B /* RxSwift */ = {
+		C8A56AD61AD7424700B4673B /* BuzzRxSwift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C8A56AED1AD7424700B4673B /* Build configuration list for PBXNativeTarget "RxSwift" */;
+			buildConfigurationList = C8A56AED1AD7424700B4673B /* Build configuration list for PBXNativeTarget "BuzzRxSwift" */;
 			buildPhases = (
 				A21F589121E109AD0051AEA2 /* SwiftLint */,
 				C8A56AD41AD7424700B4673B /* Headers */,
@@ -2733,7 +2733,7 @@
 			);
 			dependencies = (
 			);
-			name = RxSwift;
+			name = BuzzRxSwift;
 			productName = RxSwift;
 			productReference = C8A56AD71AD7424700B4673B /* RxSwift.framework */;
 			productType = "com.apple.product-type.framework";
@@ -2815,7 +2815,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				C8A56AD61AD7424700B4673B /* RxSwift */,
+				C8A56AD61AD7424700B4673B /* BuzzRxSwift */,
 				C80938F51B8A71760088E94D /* RxCocoa */,
 				A2897CB3225CA1E7004EA481 /* RxRelay */,
 				C8093B4B1B8A71F00088E94D /* RxBlocking */,
@@ -3856,7 +3856,7 @@
 /* Begin PBXTargetDependency section */
 		A2897D5A225CA28F004EA481 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = A2897D59225CA28F004EA481 /* PBXContainerItemProxy */;
 		};
 		A2897D64225CBD37004EA481 /* PBXTargetDependency */ = {
@@ -3866,7 +3866,7 @@
 		};
 		C83508CA1C386F6F0027C24C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C83508C91C386F6F0027C24C /* PBXContainerItemProxy */;
 		};
 		C835097B1C3871340027C24C /* PBXTargetDependency */ = {
@@ -3881,7 +3881,7 @@
 		};
 		C83E398721890703001F4F0E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C83E398621890703001F4F0E /* PBXContainerItemProxy */;
 		};
 		C83E398921890703001F4F0E /* PBXTargetDependency */ = {
@@ -3901,7 +3901,7 @@
 		};
 		C83E398F2189070A001F4F0E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C83E398E2189070A001F4F0E /* PBXContainerItemProxy */;
 		};
 		C83E39912189070A001F4F0E /* PBXTargetDependency */ = {
@@ -3921,17 +3921,17 @@
 		};
 		C872BD1C1BC0529600D7175E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C872BD1B1BC0529600D7175E /* PBXContainerItemProxy */;
 		};
 		C872BD241BC052B800D7175E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C872BD231BC052B800D7175E /* PBXContainerItemProxy */;
 		};
 		C88FA4FE1C25C44800CCFEA4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C88FA4FF1C25C44800CCFEA4 /* PBXContainerItemProxy */;
 		};
 		C8B52BC6215434D600EAA87C /* PBXTargetDependency */ = {
@@ -3941,7 +3941,7 @@
 		};
 		C8E8BA5C1E2C181A00A4AC2C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = C8A56AD61AD7424700B4673B /* RxSwift */;
+			target = C8A56AD61AD7424700B4673B /* BuzzRxSwift */;
 			targetProxy = C8E8BA5B1E2C181A00A4AC2C /* PBXContainerItemProxy */;
 		};
 		C8E8BA761E2C1BB200A4AC2C /* PBXTargetDependency */ = {
@@ -4803,7 +4803,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C8A56AED1AD7424700B4673B /* Build configuration list for PBXNativeTarget "RxSwift" */ = {
+		C8A56AED1AD7424700B4673B /* Build configuration list for PBXNativeTarget "BuzzRxSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C8A56AEE1AD7424700B4673B /* Debug */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -97,12 +97,12 @@
 		A2690E7E22688CAE0032C00E /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8093BC71B8A71F00088E94D /* RxBlocking.framework */; };
 		A2690E7F22688CAE0032C00E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88FA50C1C25C44800CCFEA4 /* RxTest.framework */; };
 		A2690E8022688CAE0032C00E /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2897D53225CA1E7004EA481 /* RxRelay.framework */; };
-		A2690E8122688CB50032C00E /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* RxSwift.framework */; };
+		A2690E8122688CB50032C00E /* BuzzRxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */; };
 		A2690E8222688CB50032C00E /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C809396D1B8A71760088E94D /* RxCocoa.framework */; };
 		A2690E8322688CB50032C00E /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8093BC71B8A71F00088E94D /* RxBlocking.framework */; };
 		A2690E8422688CB50032C00E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88FA50C1C25C44800CCFEA4 /* RxTest.framework */; };
 		A2690E8522688CB50032C00E /* RxRelay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A2897D53225CA1E7004EA481 /* RxRelay.framework */; };
-		A2690E8622688CB80032C00E /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* RxSwift.framework */; };
+		A2690E8622688CB80032C00E /* BuzzRxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */; };
 		A2690E8722688CB80032C00E /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C809396D1B8A71760088E94D /* RxCocoa.framework */; };
 		A2690E8822688CB80032C00E /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8093BC71B8A71F00088E94D /* RxBlocking.framework */; };
 		A2690E8922688CB80032C00E /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C88FA50C1C25C44800CCFEA4 /* RxTest.framework */; };
@@ -421,7 +421,7 @@
 		C834F6C31DB394E100C29244 /* Observable+BlockingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C11DB394E100C29244 /* Observable+BlockingTest.swift */; };
 		C834F6C41DB394E100C29244 /* Observable+BlockingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C11DB394E100C29244 /* Observable+BlockingTest.swift */; };
 		C834F6C61DB3950600C29244 /* NSControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C51DB3950600C29244 /* NSControl+RxTests.swift */; };
-		C83508C81C386F6F0027C24C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* RxSwift.framework */; };
+		C83508C81C386F6F0027C24C /* BuzzRxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */; };
 		C835092E1C38706E0027C24C /* ControlEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DD1C38706D0027C24C /* ControlEventTests.swift */; };
 		C835092F1C38706E0027C24C /* ControlPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DE1C38706D0027C24C /* ControlPropertyTests.swift */; };
 		C83509311C38706E0027C24C /* DelegateProxyTest+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */; };
@@ -768,7 +768,7 @@
 		C8E390681F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
 		C8E390691F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
 		C8E3906A1F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
-		C8E8BA5A1E2C181A00A4AC2C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* RxSwift.framework */; };
+		C8E8BA5A1E2C181A00A4AC2C /* BuzzRxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */; };
 		C8E8BA641E2C186200A4AC2C /* Benchmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA621E2C186200A4AC2C /* Benchmarks.swift */; };
 		C8E8BA721E2C18AE00A4AC2C /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA6F1E2C18AE00A4AC2C /* main.swift */; };
 		C8F03F411DBB98DB00AECC4C /* Anomalies.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F401DBB98DB00AECC4C /* Anomalies.swift */; };
@@ -1391,7 +1391,7 @@
 		C89CFA1D1DAABBE20079D23B /* XCTest+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTest+Rx.swift"; sourceTree = "<group>"; };
 		C8A53ADF1F09178700490535 /* Completable+AndThen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Completable+AndThen.swift"; sourceTree = "<group>"; };
 		C8A53AE41F09292A00490535 /* Completable+AndThen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Completable+AndThen.swift"; sourceTree = "<group>"; };
-		C8A56AD71AD7424700B4673B /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BuzzRxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8A81C9F1E05E82C0008DEF4 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
 		C8A9B6F31DAD752200C9B027 /* Observable+BindTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+BindTests.swift"; sourceTree = "<group>"; };
 		C8ADC18D2200F9B000B611D4 /* Atomic+Overrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Atomic+Overrides.swift"; sourceTree = "<group>"; };
@@ -1499,7 +1499,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C83508C81C386F6F0027C24C /* RxSwift.framework in Frameworks */,
+				C83508C81C386F6F0027C24C /* BuzzRxSwift.framework in Frameworks */,
 				A2690E7D22688CAE0032C00E /* RxCocoa.framework in Frameworks */,
 				A2690E7E22688CAE0032C00E /* RxBlocking.framework in Frameworks */,
 				A2690E7F22688CAE0032C00E /* RxTest.framework in Frameworks */,
@@ -1511,7 +1511,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2690E8122688CB50032C00E /* RxSwift.framework in Frameworks */,
+				A2690E8122688CB50032C00E /* BuzzRxSwift.framework in Frameworks */,
 				A2690E8222688CB50032C00E /* RxCocoa.framework in Frameworks */,
 				A2690E8322688CB50032C00E /* RxBlocking.framework in Frameworks */,
 				A2690E8422688CB50032C00E /* RxTest.framework in Frameworks */,
@@ -1523,7 +1523,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A2690E8622688CB80032C00E /* RxSwift.framework in Frameworks */,
+				A2690E8622688CB80032C00E /* BuzzRxSwift.framework in Frameworks */,
 				A2690E8722688CB80032C00E /* RxCocoa.framework in Frameworks */,
 				A2690E8822688CB80032C00E /* RxBlocking.framework in Frameworks */,
 				A2690E8922688CB80032C00E /* RxTest.framework in Frameworks */,
@@ -1556,7 +1556,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C8E8BA5A1E2C181A00A4AC2C /* RxSwift.framework in Frameworks */,
+				C8E8BA5A1E2C181A00A4AC2C /* BuzzRxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2443,7 +2443,7 @@
 		C8A56AD81AD7424700B4673B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				C8A56AD71AD7424700B4673B /* RxSwift.framework */,
+				C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */,
 				C809396D1B8A71760088E94D /* RxCocoa.framework */,
 				C8093BC71B8A71F00088E94D /* RxBlocking.framework */,
 				C88FA50C1C25C44800CCFEA4 /* RxTest.framework */,
@@ -2735,7 +2735,7 @@
 			);
 			name = BuzzRxSwift;
 			productName = RxSwift;
-			productReference = C8A56AD71AD7424700B4673B /* RxSwift.framework */;
+			productReference = C8A56AD71AD7424700B4673B /* BuzzRxSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		C8E8BA541E2C181A00A4AC2C /* Benchmarks */ = {
@@ -4408,7 +4408,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.buzzvil.BuzzRxSwift;
-				PRODUCT_NAME = RxSwift;
+				PRODUCT_NAME = BuzzRxSwift;
 				SKIP_INSTALL = YES;
 			};
 			name = "Release-Tests";
@@ -4626,7 +4626,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.buzzvil.BuzzRxSwift;
-				PRODUCT_NAME = RxSwift;
+				PRODUCT_NAME = BuzzRxSwift;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -4642,7 +4642,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.buzzvil.BuzzRxSwift;
-				PRODUCT_NAME = RxSwift;
+				PRODUCT_NAME = BuzzRxSwift;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/Rx.xcodeproj/xcshareddata/xcschemes/BuzzRxSwift.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/BuzzRxSwift.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C8A56AD61AD7424700B4673B"
-               BuildableName = "RxSwift.framework"
+               BuildableName = "BuzzRxSwift.framework"
                BlueprintName = "BuzzRxSwift"
                ReferencedContainer = "container:Rx.xcodeproj">
             </BuildableReference>
@@ -44,7 +44,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C8A56AD61AD7424700B4673B"
-            BuildableName = "RxSwift.framework"
+            BuildableName = "BuzzRxSwift.framework"
             BlueprintName = "BuzzRxSwift"
             ReferencedContainer = "container:Rx.xcodeproj">
          </BuildableReference>
@@ -60,7 +60,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C8A56AD61AD7424700B4673B"
-            BuildableName = "RxSwift.framework"
+            BuildableName = "BuzzRxSwift.framework"
             BlueprintName = "BuzzRxSwift"
             ReferencedContainer = "container:Rx.xcodeproj">
          </BuildableReference>

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C8A56AD61AD7424700B4673B"
                BuildableName = "RxSwift.framework"
-               BlueprintName = "RxSwift"
+               BlueprintName = "BuzzRxSwift"
                ReferencedContainer = "container:Rx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -45,7 +45,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C8A56AD61AD7424700B4673B"
             BuildableName = "RxSwift.framework"
-            BlueprintName = "RxSwift"
+            BlueprintName = "BuzzRxSwift"
             ReferencedContainer = "container:Rx.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -61,7 +61,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "C8A56AD61AD7424700B4673B"
             BuildableName = "RxSwift.framework"
-            BlueprintName = "RxSwift"
+            BlueprintName = "BuzzRxSwift"
             ReferencedContainer = "container:Rx.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// The `MaterializedSequenceResult` enum represents the materialized
 /// output of a BlockingObservable.

--- a/RxBlocking/BlockingObservable.swift
+++ b/RxBlocking/BlockingObservable.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import RxSwift
+import BuzzRxSwift
 
 /**
 `BlockingObservable` is a variety of `Observable` that provides blocking operators. 

--- a/RxBlocking/ObservableConvertibleType+Blocking.swift
+++ b/RxBlocking/ObservableConvertibleType+Blocking.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import Foundation
 
 extension ObservableConvertibleType {

--- a/RxBlocking/Resources.swift
+++ b/RxBlocking/Resources.swift
@@ -6,24 +6,24 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 #if TRACE_RESOURCES
     struct Resources {
         static func incrementTotal() -> Int32 {
-            return RxSwift.Resources.incrementTotal()
+            return BuzzRxSwift.Resources.incrementTotal()
         }
 
         static func decrementTotal() -> Int32 {
-            return RxSwift.Resources.decrementTotal()
+            return BuzzRxSwift.Resources.decrementTotal()
         }
 
         static var numberOfSerialDispatchQueueObservables: Int32 {
-            return RxSwift.Resources.numberOfSerialDispatchQueueObservables
+            return BuzzRxSwift.Resources.numberOfSerialDispatchQueueObservables
         }
 
         static var total: Int32 {
-            return RxSwift.Resources.total
+            return BuzzRxSwift.Resources.total
         }
     }
 #endif

--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -8,7 +8,7 @@
 
 import CoreFoundation
 import Foundation
-import RxSwift
+import BuzzRxSwift
 
 #if os(Linux)
     import Foundation

--- a/RxCocoa/Common/ControlTarget.swift
+++ b/RxCocoa/Common/ControlTarget.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS) || os(macOS)
 
-import RxSwift
+import BuzzRxSwift
 
 #if os(iOS) || os(tvOS)
     import UIKit

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -8,7 +8,7 @@
 
 #if !os(Linux)
 
-    import RxSwift
+    import BuzzRxSwift
     #if SWIFT_PACKAGE && !os(Linux)
         import RxCocoaRuntime
     #endif

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -9,7 +9,7 @@
 #if !os(Linux)
 
     import Foundation
-    import RxSwift
+    import BuzzRxSwift
 
 /**
 `DelegateProxyType` protocol enables using both normal delegates and Rx observable sequences with

--- a/RxCocoa/Common/Infallible+Bind.swift
+++ b/RxCocoa/Common/Infallible+Bind.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension InfallibleType {
     /**

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ObservableType {
     /**

--- a/RxCocoa/Common/RxTarget.swift
+++ b/RxCocoa/Common/RxTarget.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-import RxSwift
+import BuzzRxSwift
 
 class RxTarget : NSObject
                , Disposable {

--- a/RxCocoa/Common/TextInput.swift
+++ b/RxCocoa/Common/TextInput.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 #if os(iOS) || os(tvOS)
     import UIKit

--- a/RxCocoa/Foundation/KVORepresentable+CoreGraphics.swift
+++ b/RxCocoa/Foundation/KVORepresentable+CoreGraphics.swift
@@ -8,7 +8,7 @@
 
 #if !os(Linux)
 
-import RxSwift
+import BuzzRxSwift
 import CoreGraphics
 
 import Foundation

--- a/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
@@ -9,7 +9,7 @@
 #if !os(Linux)
 
 import Foundation
-import RxSwift
+import BuzzRxSwift
 
 /// Key value observing options
 public struct KeyValueObservingOptions: OptionSet {

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -8,7 +8,7 @@
 
 #if !os(Linux)
 
-import RxSwift
+import BuzzRxSwift
 
 import Foundation
 

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -9,7 +9,7 @@
 #if !os(Linux)
 
 import Foundation
-import RxSwift
+import BuzzRxSwift
 #if SWIFT_PACKAGE && !DISABLE_SWIZZLING && !os(Linux)
     import RxCocoaRuntime
 #endif

--- a/RxCocoa/Foundation/NotificationCenter+Rx.swift
+++ b/RxCocoa/Foundation/NotificationCenter+Rx.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: NotificationCenter {
     /**

--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import RxSwift
+import BuzzRxSwift
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking

--- a/RxCocoa/RxCocoa.swift
+++ b/RxCocoa/RxCocoa.swift
@@ -11,7 +11,7 @@ import Foundation
 // Importing RxCocoa also imports RxRelay
 @_exported import RxRelay
 
-import RxSwift
+import BuzzRxSwift
 #if os(iOS)
     import UIKit
 #endif

--- a/RxCocoa/Traits/ControlEvent.swift
+++ b/RxCocoa/Traits/ControlEvent.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// A protocol that extends `ControlEvent`.
 public protocol ControlEventType : ObservableType {

--- a/RxCocoa/Traits/ControlProperty.swift
+++ b/RxCocoa/Traits/ControlProperty.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// Protocol that enables extension of `ControlProperty`.
 public protocol ControlPropertyType : ObservableType, ObserverType {

--- a/RxCocoa/Traits/Driver/BehaviorRelay+Driver.swift
+++ b/RxCocoa/Traits/Driver/BehaviorRelay+Driver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import RxRelay
 
 extension BehaviorRelay {

--- a/RxCocoa/Traits/Driver/ControlEvent+Driver.swift
+++ b/RxCocoa/Traits/Driver/ControlEvent+Driver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
     
 extension ControlEvent {
     /// Converts `ControlEvent` to `Driver` trait.

--- a/RxCocoa/Traits/Driver/ControlProperty+Driver.swift
+++ b/RxCocoa/Traits/Driver/ControlProperty+Driver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ControlProperty {
     /// Converts `ControlProperty` to `Driver` trait.

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import RxRelay
 
 private let errorMessage = "`drive*` family of methods can be only called from `MainThread`.\n" +

--- a/RxCocoa/Traits/Driver/Driver.swift
+++ b/RxCocoa/Traits/Driver/Driver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /**
  Trait that represents observable sequence with following properties:

--- a/RxCocoa/Traits/Driver/Infallible+Driver.swift
+++ b/RxCocoa/Traits/Driver/Infallible+Driver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension InfallibleType {
     /// Converts `InfallibleType` to `Driver`.

--- a/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
+++ b/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ObservableConvertibleType {
     /**

--- a/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ObservableConvertibleType {
     /**

--- a/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 public enum SharingScheduler {
     /// Default scheduler used in SharedSequence based traits.

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
@@ -7,7 +7,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.tt
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.tt
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 <% for i in 2 ... 8 { %>
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 // MARK: map
 extension SharedSequenceConvertibleType {

--- a/RxCocoa/Traits/SharedSequence/SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /**
     Trait that represents observable sequence that shares computation resources with following properties:

--- a/RxCocoa/Traits/Signal/ControlEvent+Signal.swift
+++ b/RxCocoa/Traits/Signal/ControlEvent+Signal.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ControlEvent {
     /// Converts `ControlEvent` to `Signal` trait.

--- a/RxCocoa/Traits/Signal/ObservableConvertibleType+Signal.swift
+++ b/RxCocoa/Traits/Signal/ObservableConvertibleType+Signal.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ObservableConvertibleType {
     /**

--- a/RxCocoa/Traits/Signal/PublishRelay+Signal.swift
+++ b/RxCocoa/Traits/Signal/PublishRelay+Signal.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import RxRelay
 
 extension PublishRelay {

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import RxRelay
 
 extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingStrategy {

--- a/RxCocoa/Traits/Signal/Signal.swift
+++ b/RxCocoa/Traits/Signal/Signal.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /**
  Trait that represents observable sequence with following properties:

--- a/RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift
+++ b/RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 // objc monkey business
 class _RxCollectionViewReactiveArrayDataSource

--- a/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
+++ b/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 class RxPickerViewArrayDataSource<T>: NSObject, UIPickerViewDataSource, SectionedViewDataSourceType {
     fileprivate var items: [T] = []

--- a/RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift
+++ b/RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 // objc monkey business
 class _RxTableViewReactiveArrayDataSource

--- a/RxCocoa/iOS/NSTextStorage+Rx.swift
+++ b/RxCocoa/iOS/NSTextStorage+Rx.swift
@@ -7,7 +7,7 @@
 //
 
 #if os(iOS) || os(tvOS)
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
     
     extension Reactive where Base: NSTextStorage {

--- a/RxCocoa/iOS/Protocols/RxCollectionViewDataSourceType.swift
+++ b/RxCocoa/iOS/Protocols/RxCollectionViewDataSourceType.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /// Marks data source as `UICollectionView` reactive data source enabling it to be used with one of the `bindTo` methods.
 public protocol RxCollectionViewDataSourceType /*: UICollectionViewDataSource*/ {

--- a/RxCocoa/iOS/Protocols/RxPickerViewDataSourceType.swift
+++ b/RxCocoa/iOS/Protocols/RxPickerViewDataSourceType.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
     
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /// Marks data source as `UIPickerView` reactive data source enabling it to be used with one of the `bindTo` methods.
 public protocol RxPickerViewDataSourceType {

--- a/RxCocoa/iOS/Protocols/RxTableViewDataSourceType.swift
+++ b/RxCocoa/iOS/Protocols/RxTableViewDataSourceType.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /// Marks data source as `UITableView` reactive data source enabling it to be used with one of the `bindTo` methods.
 public protocol RxTableViewDataSourceType /*: UITableViewDataSource*/ {

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 @available(iOS 10.0, tvOS 10.0, *)
 extension UICollectionView: HasPrefetchDataSource {

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension UICollectionView: HasDataSource {
     public typealias DataSource = UICollectionViewDataSource

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxCollectionViewDelegateProxy

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
     import UIKit
-    import RxSwift
+    import BuzzRxSwift
 
     extension UINavigationController: HasDelegate {
         public typealias Delegate = UINavigationControllerDelegate

--- a/RxCocoa/iOS/Proxies/RxPickerViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDataSourceProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension UIPickerView: HasDataSource {
     public typealias DataSource = UIPickerViewDataSource

--- a/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
 
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
 
     extension UIPickerView: HasDelegate {

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
     
 extension UIScrollView: HasDelegate {

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension UISearchBar: HasDelegate {
     public typealias Delegate = UISearchBarDelegate

--- a/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension UISearchController: HasDelegate {

--- a/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension UITabBarController: HasDelegate {
     public typealias Delegate = UITabBarControllerDelegate

--- a/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension UITabBar: HasDelegate {
     public typealias Delegate = UITabBarDelegate

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourcePrefetchingProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourcePrefetchingProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 @available(iOS 10.0, tvOS 10.0, *)
 extension UITableView: HasPrefetchDataSource {

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
     
 extension UITableView: HasDataSource {
     public typealias DataSource = UITableViewDataSource

--- a/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxTableViewDelegateProxy

--- a/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
 
     extension NSTextStorage: HasDelegate {

--- a/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxTextViewDelegateProxy

--- a/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(macOS)
 
-import RxSwift
+import BuzzRxSwift
 import WebKit
 
 @available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)

--- a/RxCocoa/iOS/UIActivityIndicatorView+Rx.swift
+++ b/RxCocoa/iOS/UIActivityIndicatorView+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UIActivityIndicatorView {
     /// Bindable sink for `startAnimating()`, `stopAnimating()` methods.

--- a/RxCocoa/iOS/UIApplication+Rx.swift
+++ b/RxCocoa/iOS/UIApplication+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UIApplication {
     /// Bindable sink for `isNetworkActivityIndicatorVisible`.

--- a/RxCocoa/iOS/UIBarButtonItem+Rx.swift
+++ b/RxCocoa/iOS/UIBarButtonItem+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 private var rx_tap_key: UInt8 = 0
 

--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UIButton {
@@ -23,7 +23,7 @@ extension Reactive where Base: UIButton {
 
 #if os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UIButton {
@@ -39,7 +39,7 @@ extension Reactive where Base: UIButton {
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UIButton {
@@ -68,7 +68,7 @@ extension Reactive where Base: UIButton {
 #endif
 
 #if os(iOS) || os(tvOS)
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
     
     extension Reactive where Base: UIButton {

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 // Items

--- a/RxCocoa/iOS/UIControl+Rx.swift
+++ b/RxCocoa/iOS/UIControl+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UIControl {

--- a/RxCocoa/iOS/UIDatePicker+Rx.swift
+++ b/RxCocoa/iOS/UIDatePicker+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UIDatePicker {

--- a/RxCocoa/iOS/UIGestureRecognizer+Rx.swift
+++ b/RxCocoa/iOS/UIGestureRecognizer+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 // This should be only used from `MainScheduler`
 final class GestureTarget<Recognizer: UIGestureRecognizer>: RxTarget {

--- a/RxCocoa/iOS/UINavigationController+Rx.swift
+++ b/RxCocoa/iOS/UINavigationController+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UINavigationController {

--- a/RxCocoa/iOS/UIPickerView+Rx.swift
+++ b/RxCocoa/iOS/UIPickerView+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
     
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
 
     extension Reactive where Base: UIPickerView {

--- a/RxCocoa/iOS/UIRefreshControl+Rx.swift
+++ b/RxCocoa/iOS/UIRefreshControl+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UIRefreshControl {
     /// Bindable sink for `beginRefreshing()`, `endRefreshing()` methods.

--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
 
     extension Reactive where Base: UIScrollView {

--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UISearchBar {

--- a/RxCocoa/iOS/UISearchController+Rx.swift
+++ b/RxCocoa/iOS/UISearchController+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
     
-    import RxSwift
+    import BuzzRxSwift
     import UIKit
     
     extension Reactive where Base: UISearchController {

--- a/RxCocoa/iOS/UISegmentedControl+Rx.swift
+++ b/RxCocoa/iOS/UISegmentedControl+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UISegmentedControl {
     /// Reactive wrapper for `selectedSegmentIndex` property.

--- a/RxCocoa/iOS/UISlider+Rx.swift
+++ b/RxCocoa/iOS/UISlider+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UISlider {

--- a/RxCocoa/iOS/UIStepper+Rx.swift
+++ b/RxCocoa/iOS/UIStepper+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UIStepper {
     

--- a/RxCocoa/iOS/UISwitch+Rx.swift
+++ b/RxCocoa/iOS/UISwitch+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UISwitch {
 

--- a/RxCocoa/iOS/UITabBar+Rx.swift
+++ b/RxCocoa/iOS/UITabBar+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 /**
  iOS only

--- a/RxCocoa/iOS/UITabBarController+Rx.swift
+++ b/RxCocoa/iOS/UITabBarController+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
     
 /**
  iOS only

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 // Items

--- a/RxCocoa/iOS/UITextField+Rx.swift
+++ b/RxCocoa/iOS/UITextField+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(tvOS)
 
-import RxSwift
+import BuzzRxSwift
 import UIKit
 
 extension Reactive where Base: UITextField {

--- a/RxCocoa/iOS/UITextView+Rx.swift
+++ b/RxCocoa/iOS/UITextView+Rx.swift
@@ -9,7 +9,7 @@
 #if os(iOS) || os(tvOS)
 
 import UIKit
-import RxSwift
+import BuzzRxSwift
 
 extension Reactive where Base: UITextView {
     /// Reactive wrapper for `text` property

--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(iOS) || os(macOS)
 
-import RxSwift
+import BuzzRxSwift
 import WebKit
 
 @available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)

--- a/RxCocoa/macOS/NSButton+Rx.swift
+++ b/RxCocoa/macOS/NSButton+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(macOS)
 
-import RxSwift
+import BuzzRxSwift
 import Cocoa
 
 extension Reactive where Base: NSButton {

--- a/RxCocoa/macOS/NSControl+Rx.swift
+++ b/RxCocoa/macOS/NSControl+Rx.swift
@@ -9,7 +9,7 @@
 #if os(macOS)
 
 import Cocoa
-import RxSwift
+import BuzzRxSwift
 
 private var rx_value_key: UInt8 = 0
 private var rx_control_events_key: UInt8 = 0

--- a/RxCocoa/macOS/NSSlider+Rx.swift
+++ b/RxCocoa/macOS/NSSlider+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(macOS)
 
-import RxSwift
+import BuzzRxSwift
 import Cocoa
 
 extension Reactive where Base: NSSlider {

--- a/RxCocoa/macOS/NSTextField+Rx.swift
+++ b/RxCocoa/macOS/NSTextField+Rx.swift
@@ -9,7 +9,7 @@
 #if os(macOS)
 
 import Cocoa
-import RxSwift
+import BuzzRxSwift
 
 /// Delegate proxy for `NSTextField`.
 ///

--- a/RxCocoa/macOS/NSTextView+Rx.swift
+++ b/RxCocoa/macOS/NSTextView+Rx.swift
@@ -9,7 +9,7 @@
 #if os(macOS)
 
 import Cocoa
-import RxSwift
+import BuzzRxSwift
 
 /// Delegate proxy for `NSTextView`.
 ///

--- a/RxCocoa/macOS/NSView+Rx.swift
+++ b/RxCocoa/macOS/NSView+Rx.swift
@@ -8,7 +8,7 @@
 
 #if os(macOS)
     import Cocoa
-    import RxSwift
+    import BuzzRxSwift
 
     extension Reactive where Base: NSView {
         /// Bindable sink for `alphaValue` property.

--- a/RxRelay/BehaviorRelay.swift
+++ b/RxRelay/BehaviorRelay.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// BehaviorRelay is a wrapper for `BehaviorSubject`.
 ///

--- a/RxRelay/Observable+Bind.swift
+++ b/RxRelay/Observable+Bind.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension ObservableType {
     /**

--- a/RxRelay/PublishRelay.swift
+++ b/RxRelay/PublishRelay.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// PublishRelay is a wrapper for `PublishSubject`.
 ///

--- a/RxRelay/ReplayRelay.swift
+++ b/RxRelay/ReplayRelay.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// ReplayRelay is a wrapper for `ReplaySubject`.
 ///

--- a/RxTest/ColdObservable.swift
+++ b/RxTest/ColdObservable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// A representation of cold observable sequence.
 ///

--- a/RxTest/Event+Equatable.swift
+++ b/RxTest/Event+Equatable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import Foundation
 
 internal func equals<Element: Equatable>(lhs: Event<Element>, rhs: Event<Element>) -> Bool {

--- a/RxTest/HotObservable.swift
+++ b/RxTest/HotObservable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// A representation of hot observable sequence.
 ///

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 extension Recorded {
     

--- a/RxTest/Recorded.swift
+++ b/RxTest/Recorded.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 import Swift
 
 /// Record of a value including the virtual time it was produced on.

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// Virtual time scheduler used for testing applications and libraries built using RxSwift.
 public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConverter> {

--- a/RxTest/Schedulers/TestSchedulerVirtualTimeConverter.swift
+++ b/RxTest/Schedulers/TestSchedulerVirtualTimeConverter.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import RxSwift
+import BuzzRxSwift
 
 /// Converter from virtual time and time interval measured in `Int`s to `Date` and `NSTimeInterval`.
 public struct TestSchedulerVirtualTimeConverter : VirtualTimeConverterType {

--- a/RxTest/TestableObservable.swift
+++ b/RxTest/TestableObservable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// Observable sequence that records subscription lifetimes and timestamped events sent to observers.
 public class TestableObservable<Element>

--- a/RxTest/TestableObserver.swift
+++ b/RxTest/TestableObserver.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
+import BuzzRxSwift
 
 /// Observer that records events together with virtual time when they were received.
 public final class TestableObserver<Element>

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -7,7 +7,7 @@
 //
 
 #if !os(watchOS)
-import RxSwift
+import BuzzRxSwift
 import XCTest
 /**
 Asserts two lists of events are equal.

--- a/Tests/Resources.swift
+++ b/Tests/Resources.swift
@@ -11,19 +11,19 @@ import RxSwift
 #if TRACE_RESOURCES
     struct Resources {
         static func incrementTotal() -> Int32 {
-            return RxSwift.Resources.incrementTotal()
+            return BuzzRxSwift.Resources.incrementTotal()
         }
 
         static func decrementTotal() -> Int32 {
-            return RxSwift.Resources.decrementTotal()
+            return BuzzRxSwift.Resources.decrementTotal()
         }
 
         static var numberOfSerialDispatchQueueObservables: Int32 {
-            return RxSwift.Resources.numberOfSerialDispatchQueueObservables
+            return BuzzRxSwift.Resources.numberOfSerialDispatchQueueObservables
         }
 
         static var total: Int32 {
-            return RxSwift.Resources.total
+            return BuzzRxSwift.Resources.total
         }
     }
 #endif


### PR DESCRIPTION
## Introduction

RxSwift target 이름을 BuzzRxSwift으로 변경하였습니다. Target 이름을 변경함으로서 프레임워크 소비자가 오픈 소스 라이브러리인 RxSwift와 독립적으로 BuzzRxSwift를 사용할 수 있게 하는 것이 목표입니다. 배포 설정 변경과 관련된 작업은 별도 PR에서 진행할 예정입니다. 작업 내역은 다음과 같습니다.

- RxSwift target 이름을 BuzzRxSwift로 변경
- RxSwift bundle identifier를 io.rx.RxSwift에서 com.buzzvil.BuzzRxSwift로 변경
- RxSwift `PRODUCT_NAME`을 BuzzRxSwift로 변경
- RxSwift scheme 이름을 BuzzRxSwift로 변경
- RxCocoa, RxTest, RxBlocking의 import 문에서 RxSwift 모듈을 참조하는 부분 변경

## Motivation

RxSwift fork 리포지토리를 upstream과 독립적으로 사용 및 배포할 수 있는 환경 조성을 위한 하위작업입니다. 작업의 주된 목적은 퍼블리셔가 사용하는 RxSwift와 우리가 사용하는 RxSwift의 버전 충돌을 방지하기 위함입니다.

as-is
```mermaid
flowchart LR
  App --> BuzzAdBenefit
  App & BuzzAdBenefit --> RxSwift
```

to-be
```mermaid
flowchart LR
  App --> BuzzAdBenefit
  App --> RxSwift
  BuzzAdBenefit --> BuzzRxSwift
```

## Effect on Existing Targets

이 작업이 반영되어도 BuzzRxSwift, RxCocoa, RxRelay, RxTest, RxBlocking 빌드에 성공합니다. 단, 다음 target의 빌드가 실패합니다.  
- Playground target 빌드 실패
- 유닛 테스트 target 빌드 실패

Playground와 유닛 테스트 타겟은 의도적으로 `import RxSwift` 문을 `import BuzzRxSwift`로 변경해두지 않았습니다. 꼭 빌드에 성공하지 않아도 주요 타겟들을 (RxSwift, RxCocoa, RxRelay, RxTest, RxBlocking) 배포할 수 있고 upstream 리포지토리를 fetch할 떄 불필요한 conflict를 줄일 수 있을 것 같아서입니다. 다만 Playground 및 유닛 테스트가 빌드에 성공하도록 유지하는 것도 어느정도 장점이 있다고 생각해서 의견 주시면 수정하도록 하겠습니다.
