### PR TITLE
[OUTPUT-3525] Update package for buzzvil spm usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,75 +1,22 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
-
-let buildTests = false
-
-extension Product {
-  static func allTests() -> [Product] {
-    if buildTests {
-      return [.executable(name: "AllTestz", targets: ["AllTestz"])]
-    } else {
-      return []
-    }
-  }
-}
-
-extension Target {
-  static func rxCocoa() -> [Target] {
-    #if os(Linux)
-      return [.target(name: "RxCocoa", dependencies: ["RxSwift", "RxRelay"])]
-    #else
-      return [.target(name: "RxCocoa", dependencies: ["RxSwift", "RxRelay", "RxCocoaRuntime"])]
-    #endif
-  }
-
-  static func rxCocoaRuntime() -> [Target] {
-    #if os(Linux)
-      return []
-    #else
-      return [.target(name: "RxCocoaRuntime", dependencies: ["RxSwift"])]
-    #endif
-  }
-
-  static func allTests() -> [Target] {
-    if buildTests {
-      return [.target(name: "AllTestz", dependencies: ["RxSwift", "RxCocoa", "RxBlocking", "RxTest"])]
-    } else {
-      return []
-    }
-  }
-}
 
 let package = Package(
   name: "RxSwift",
   platforms: [.iOS(.v9), .macOS(.v10_10), .watchOS(.v3), .tvOS(.v9)],
-  products: ([
-    [
-      .library(name: "RxSwift", targets: ["RxSwift"]),
-      .library(name: "RxCocoa", targets: ["RxCocoa"]),
-      .library(name: "RxRelay", targets: ["RxRelay"]),
-      .library(name: "RxBlocking", targets: ["RxBlocking"]),
-      .library(name: "RxTest", targets: ["RxTest"]),
-      .library(name: "RxSwift-Dynamic", type: .dynamic, targets: ["RxSwift"]),
-      .library(name: "RxCocoa-Dynamic", type: .dynamic, targets: ["RxCocoa"]),
-      .library(name: "RxRelay-Dynamic", type: .dynamic, targets: ["RxRelay"]),
-      .library(name: "RxBlocking-Dynamic", type: .dynamic, targets: ["RxBlocking"]),
-      .library(name: "RxTest-Dynamic", type: .dynamic, targets: ["RxTest"]),
-    ],
-    Product.allTests()
-  ] as [[Product]]).flatMap { $0 },
-  targets: ([
-    [
-      .target(name: "RxSwift", dependencies: []),
-    ], 
-    Target.rxCocoa(),
-    Target.rxCocoaRuntime(),
-    [
-      .target(name: "RxRelay", dependencies: ["RxSwift"]),
-      .target(name: "RxBlocking", dependencies: ["RxSwift"]),
-      .target(name: "RxTest", dependencies: ["RxSwift"]),
-    ],
-    Target.allTests()
-  ] as [[Target]]).flatMap { $0 },
+  products: [
+    .library(
+      name: "RxSwift",
+      targets: ["RxSwift"]
+    )
+  ],
+  targets: [
+    .binaryTarget(
+      name: "RxSwift",
+      url: "https://github.com/Buzzvil/RxSwift/releases/download/v7.0.0/BuzzRxSwift.zip",
+      checksum: "772edfb6e77b41f888d4430e46e00d1ec147dc9d26b3f2ce464dbc00d678f963"
+    )
+  ],
   swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
- Usage : `.package(url: "https://github.com/Buzzvil/RxSwift", branch: "buzzvil-main"),`
- Use released xcframework for binaryTarget
- Remove unused products